### PR TITLE
WIP/RFC: normalmaps

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -174,9 +174,23 @@ static void spine_free(void *ptr) {
 
 class ResourceFormatLoaderSpine : public ResourceFormatLoader {
 public:
+	ResourceFormatLoaderSpine() {
+#ifdef DEBUG_ENABLED
+		print_line("Spine: ResourceFormatLoaderSpine constructed");
+#endif
+	}
+
+	~ResourceFormatLoaderSpine() {
+#ifdef DEBUG_ENABLED
+		print_line("Spine: ResourceFormatLoaderSpine destructed");
+#endif
+	}
+
 
 	virtual RES load(const String &p_path, const String& p_original_path = "", Error *p_err=NULL) {
+#ifdef DEBUG_ENABLED
 		float start = OS::get_singleton()->get_ticks_msec();
+#endif
 
 		Spine::SpineResource *res = memnew(Spine::SpineResource);
 		Ref<Spine::SpineResource> ref(res);
@@ -234,8 +248,10 @@ public:
 		}
 
 		res->set_path(p_path);
+#ifdef DEBUG_ENABLED
 		float finish = OS::get_singleton()->get_ticks_msec();
-		// print_line("Spine resource (" + p_path + ") loaded in " + itos(finish-start) + " msecs");
+		print_line("Spine resource (" + p_path + ") loaded in " + itos(finish-start) + " msecs");
+#endif
 		return ref;
 	}
 

--- a/spine.cpp
+++ b/spine.cpp
@@ -44,6 +44,9 @@ Spine::SpineResource::SpineResource() {
 
 	atlas = NULL;
 	data = NULL;
+
+	nm_atlas = NULL;
+	nm_data = NULL;
 }
 
 Spine::SpineResource::~SpineResource() {
@@ -53,6 +56,12 @@ Spine::SpineResource::~SpineResource() {
 
 	if (data != NULL)
 		spSkeletonData_dispose(data);
+
+	if (nm_atlas != NULL)
+		spAtlas_dispose(nm_atlas);
+
+	if (nm_data != NULL)
+		spSkeletonData_dispose(nm_data);
 }
 
 Array *Spine::invalid_names = NULL;

--- a/spine.cpp
+++ b/spine.cpp
@@ -173,6 +173,7 @@ void Spine::draw_slot(SpineSlot *spine_slot) {
 		return;
 
 	auto slot = spine_slot->slot;
+	auto nm_slot = spine_slot->nm_slot;
 
 	if (!slot->attachment)
 		return;
@@ -192,12 +193,16 @@ void Spine::draw_slot(SpineSlot *spine_slot) {
 
 	bool is_fx = false;
 	Ref<Texture> texture;
+	Ref<Texture> nm_texture;
 
 	switch (slot->attachment->type) {
 
 		case SP_ATTACHMENT_REGION: {
 			spRegionAttachment *attachment = (spRegionAttachment *)slot->attachment;
 			is_fx = strstr(attachment->path, fx_prefix) != NULL;
+
+			spRegionAttachment *nm_attachment = NULL;
+			if (nm_slot) nm_attachment = (spRegionAttachment *)nm_slot->attachment;
 
 			// get points from Spine (2 pairs of x/ys for 4 points)
 			float spPoints[10];
@@ -207,6 +212,8 @@ void Spine::draw_slot(SpineSlot *spine_slot) {
 			// get texture and uvs from Spine
 			texture = spine_get_texture(attachment);
 			const float *spUVs = attachment->uvs;
+
+			if (nm_attachment) nm_texture = spine_get_texture(nm_attachment);
 
 			// the indices are fixed
 			static int spIndices[6] = { 0, 1, 2, 2, 3, 0 };
@@ -231,24 +238,29 @@ void Spine::draw_slot(SpineSlot *spine_slot) {
 				p_colors.push_back(color);
 				p_uvs.push_back(Vector2(spUVs[atPoint], spUVs[atPoint + 1]));
 			}
-			
+
 			Vector<int> p_indices;
 			p_indices.resize(spIndicesCount);
 			memcpy(p_indices.ptrw(), spIndices, spIndicesCount * sizeof(int));
-			
+
 			VisualServer::get_singleton()->canvas_item_add_triangle_array(spine_slot->get_canvas_item(),
 					p_indices,
 					p_points,
 					p_colors,
 					p_uvs,
-					Vector<int>(),
-					Vector<float>(),
-					texture->get_rid());
+					Vector<int>(),    // bones
+					Vector<float>(),  // weights
+					texture->get_rid(),
+					-1,               // int p_count = -1
+					nm_texture.is_null() ? RID() : nm_texture->get_rid());
 			break;
 		}
 		case SP_ATTACHMENT_MESH: {
 			spMeshAttachment *attachment = (spMeshAttachment *)slot->attachment;
 			is_fx = strstr(attachment->path, fx_prefix) != NULL;
+
+			spMeshAttachment *nm_attachment = NULL;
+			if (nm_slot) nm_attachment = (spMeshAttachment *)nm_slot->attachment;
 
 			// get points from Spine (2 pairs of x/ys for 4 points)
 			spVertexAttachment_computeWorldVertices(SUPER(attachment), slot, 0, attachment->super.worldVerticesLength, world_verts.ptrw(), 0, 2);
@@ -258,6 +270,8 @@ void Spine::draw_slot(SpineSlot *spine_slot) {
 			// get texture and uvs from Spine
 			texture = spine_get_texture(attachment);
 			const float *spUVs = attachment->uvs;
+
+			if (nm_attachment) nm_texture = spine_get_texture(nm_attachment);
 
 			// the indices are fixed
 			unsigned short *spIndices = attachment->triangles;
@@ -293,9 +307,11 @@ void Spine::draw_slot(SpineSlot *spine_slot) {
 					p_points,
 					p_colors,
 					p_uvs,
-					Vector<int>(),
-					Vector<float>(),
-					texture->get_rid());
+					Vector<int>(),    // bones
+					Vector<float>(),  // weights
+					texture->get_rid(),
+					-1,               // int p_count = -1
+					nm_texture.is_null() ? RID() : nm_texture->get_rid());
 			break;
 		}
 
@@ -692,7 +708,7 @@ void Spine::_notification(int p_what) {
 			if (processing) {
 				_animation_process(get_process_delta_time());
 				_update_children();
-			}	
+			}
 		} break;
 		case NOTIFICATION_PHYSICS_PROCESS: {
 
@@ -703,7 +719,7 @@ void Spine::_notification(int p_what) {
 				_animation_process(get_physics_process_delta_time());
 				_update_children();
 			}
-				
+
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -753,6 +769,8 @@ void Spine::set_resource(Ref<Spine::SpineResource> p_data) {
 		nm_state = spAnimationState_create(spAnimationStateData_create(nm_skeleton->data));
 		nm_state->rendererObject = this;
 		nm_state->listener = spine_animation_callback;
+	} else {
+		nm_skeleton = NULL;
 	}
 
 	_update_verties_count();
@@ -772,8 +790,10 @@ void Spine::set_resource(Ref<Spine::SpineResource> p_data) {
 
 	for (int i = 0, n = skeleton->slotsCount; i < n; i++) {
 		spSlot *slot = skeleton->drawOrder[i];
+		spSlot *nm_slot = NULL;
+		if (nm_skeleton) nm_slot = nm_skeleton->drawOrder[i];
 		auto slot_node = memnew(SpineSlot);
-		slot_node->init(this, slot);
+		slot_node->init(this, slot, nm_slot);
 		slot_node->set_name(slot->data->name);
 		slot_node->set_z_index(i);
 		add_child(slot_node);

--- a/spine.cpp
+++ b/spine.cpp
@@ -513,7 +513,7 @@ bool Spine::_set(const StringName &p_name, const Variant &p_value) {
 				stop();
 			else if (has_animation(which)) {
 				reset();
-				play(which, 1, loop);
+				play(which, loop);
 			}
 		} else
 			current_animation = which;
@@ -528,7 +528,7 @@ bool Spine::_set(const StringName &p_name, const Variant &p_value) {
 
 		loop = p_value;
 		if (skeleton != NULL && has_animation(current_animation))
-			play(current_animation, 1, loop);
+			play(current_animation, loop);
 	} else if (name == "playback/forward") {
 
 		forward = p_value;
@@ -749,7 +749,7 @@ void Spine::set_resource(Ref<Spine::SpineResource> p_data) {
 	if (skin != "")
 		set_skin(skin);
 	if (current_animation != "[stop]")
-		play(current_animation, 1, loop);
+		play(current_animation, loop);
 	else
 		reset();
 

--- a/spine.h
+++ b/spine.h
@@ -80,6 +80,9 @@ private:
 	spAnimationState* state;
 	mutable Vector<float> world_verts;
 
+	spSkeleton* nm_skeleton;
+	spAnimationState* nm_state;
+
 	float speed_scale;
 	String autoplay;
 	AnimationProcessMode animation_process_mode;

--- a/spine.h
+++ b/spine.h
@@ -67,6 +67,9 @@ public:
 
 		spAtlas *atlas;
 		spSkeletonData *data;
+
+		spAtlas *nm_atlas;
+		spSkeletonData *nm_data;
 	};
 
 private:

--- a/spine_slot.cpp
+++ b/spine_slot.cpp
@@ -20,7 +20,7 @@ void SpineSlot::_bind_methods() {
 void SpineSlot::_notification(int p_what) {
 
 	switch (p_what) {
-		case NOTIFICATION_DRAW: {
+		case CanvasItem::NOTIFICATION_DRAW: {
 			_draw();
 		} break;
 	}

--- a/spine_slot.cpp
+++ b/spine_slot.cpp
@@ -4,11 +4,13 @@
 SpineSlot::SpineSlot() {
 	this->spine = NULL;
 	this->slot = NULL;
+	this->nm_slot = NULL;
 }
 
 SpineSlot::~SpineSlot() {
 	this->spine = NULL;
 	this->slot = NULL;
+	this->nm_slot = NULL;
 }
 
 

--- a/spine_slot.h
+++ b/spine_slot.h
@@ -16,10 +16,12 @@ protected:
 
 public:
 	spSlot *slot;
+	spSlot *nm_slot;
 
-	void init(Spine *spine, spSlot *slot) {
+	void init(Spine *spine, spSlot *slot, spSlot *nm_slot) {
 		this->spine = spine;
 		this->slot = slot;
+		this->nm_slot = nm_slot;
 	}
 
 	SpineSlot();

--- a/spine_slot.h
+++ b/spine_slot.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include "scene/2d/canvas_item.h"
+#include "core/print_string.h"
 #include "spine.h"
+
+#include <stddef.h>
 
 class SpineSlot : public Node2D {
 	GDCLASS(SpineSlot, Node2D);


### PR DESCRIPTION
As I suggested in https://github.com/EsotericSoftware/spine-runtimes/issues/728 I have spent a bit of time trying to get normal maps even to load.

My initial test was making a new `SpineResource` for it, but decided that with the resource getting grafted all over the `Spine` node, I would rather make the loading of normal maps (at least for the time being) as automagic as possible.

This code segfaults pretty much every time. I have had the occasional luck that I can execute the editor from VS Code, but it would still segfault when running the project.

Going forward with the illumination/shading, I'll have to hear it from someone or figure it out. I'm thinking I'd have to keep the regular and normal-mapped animations in sync and find some way of having Godot look at the normal maps from the normal-mapped animation. It would be more elegant if the `Texture` slots would have a normal map from the second atlas, but I don't think it's possible except for `Sprite`s.

Can the code be altered to use `Sprite`? With any luck – though I haven't had much yet! – Godot would Do The Right Thing if that was the case.

-----

I don't have an example project that I can share publicly, our assets are our own, but hopefully I can find an example at some point.

You should just have a copy of your atlas with the prefix `nm_` where your spine atlas is, and have it point to a normal map

------

Comments and clues are welcome, as I don't know how much time I have for this, and chasing down segfaults that don't make any apparent sense is one of my least favorite activities.
